### PR TITLE
Fix: Crash on loading large PML files (>8.5GB) due to offset overflow

### DIFF
--- a/Crassus/ProcMon/ProcMonPML.cs
+++ b/Crassus/ProcMon/ProcMonPML.cs
@@ -333,15 +333,9 @@ namespace Crassus.ProcMon
             {
                 uint lowerPart = reader.ReadUInt32();
                 byte upperPart = reader.ReadByte();  // Read the additional byte
-                if (upperPart == 1)
-                {
-                    LogEventOffsets[i] = lowerPart + ((long)upperPart << 32);  // Calculate the 64-bit offset
-                }
-                else
-                {
-                    LogEventOffsets[i] = lowerPart;
-                }
+                LogEventOffsets[i] = (long)lowerPart + ((long)upperPart << 32);
             }
         }
     }
 }
+


### PR DESCRIPTION
**What does this PR do?**
This PR fixes a `System.IO.IOException` ("An attempt was made to move the file pointer before the beginning of the file") that occurs when processing very large Process Monitor logs.

**The Bug:**
The previous logic in `ReadEventOffsets` explicitly checked `if (upperPart == 1)`.  In PML files larger than ~8.5GB (approx 70M+ events), the `upperPart` byte becomes `2` or higher. The original code fell through to the `else` block, ignoring the high-order bits entirely, which caused the file pointer to calculate an incorrect (often negative) offset.

**The Fix:**
I replaced the conditional check with a standard 64-bit shift operation that applies the `upperPart` regardless of its value.  `LogEventOffsets[i] = (long)lowerPart + ((long)upperPart << 32);`

**Validation:**
I tested this build against a 73-million-event PML file (approx 45GB) which previously crashed the tool. With this fix, Crassus processed the entire file successfully.